### PR TITLE
Update stick.js

### DIFF
--- a/lib/stick.js
+++ b/lib/stick.js
@@ -28,11 +28,15 @@ Stick.prototype.fireStickEvents =  function (data) {
   var _emitStickEvents = function (data) {
     var xbox = this.controller,
       position, btnRef;
-
+	
+	var deadZoneRange = 0.75;	// The range from the neutral position in which no input is received
+	var minVal = 0;					  // The minimum value of the bits sent through the buffer
+	var maxVal = 65536				// The maximum value of the bits sent through the buffer
+	
     if(this.isLinux){
-      position = this._getLinuxAxisPosition(data);
+		position = this._getLinuxAxisPosition(data);
     }else{
-      position = this._getDirectionalPosition(data);
+		position = this._getDirectionalPosition(data, minVal, maxVal);
     }
 
     btnRef = this.reference.toLowerCase();
@@ -51,33 +55,33 @@ Stick.prototype.fireStickEvents =  function (data) {
         this.lastMoveEvent = null;
       }
     }
-
-    if(position.x == 255){
-      setLastMoveEvent(btnRef + 'stickRight', 255, 'x');
+	
+    if(position.x <= 2 && position.x >= deadZoneRange){
+      setLastMoveEvent(btnRef + 'stickRight', position.x, 'x');
 
       xbox.emit(btnRef + 'stickRight');
     }else{
       xbox.emit(btnRef + 'stickRight:none');
     }
 
-    if(position.x === 0){
-      setLastMoveEvent(btnRef + 'stickLeft', 0, 'x');
+    if(position.x <= -deadZoneRange && position.x >= -2){
+      setLastMoveEvent(btnRef + 'stickLeft', position.x, 'x');
 
       xbox.emit(btnRef + 'stickLeft');
     }else{
       xbox.emit(btnRef + 'stickLeft:none');
     }
-
-    if(position.y == 255){
-      setLastMoveEvent(btnRef + 'stickDown', 255, 'y');
+	
+	if(position.y <= 2 && position.y >= deadZoneRange){
+      setLastMoveEvent(btnRef + 'stickDown', position.y, 'y');
 
       xbox.emit(btnRef + 'stickDown');
     }else{
       xbox.emit(btnRef + 'stickDown:none');
     }
 
-    if(position.y === 0){
-      setLastMoveEvent(btnRef + 'stickUp', 0, 'y');
+    if(position.y <= -deadZoneRange && position.y >= -2){
+      setLastMoveEvent(btnRef + 'stickUp', position.y, 'y');
 
       xbox.emit(btnRef + 'stickUp');
     }else{
@@ -95,12 +99,37 @@ Stick.prototype.fireStickEvents =  function (data) {
 /**
  * @private
 */
-Stick.prototype._getDirectionalPosition = function (data) {
-
-  return {
-      x: data[this.HIDCoordinates.x],
-      y: data[this.HIDCoordinates.y]
-  };
+Stick.prototype._getDirectionalPosition = function (data, min, max) {
+	// Get input in bytes from the buffer
+	var x1 = parseInt(data[this.HIDCoordinates.x]);
+	var x2 = parseInt(data[this.HIDCoordinates.x+1]);
+	
+	// Get value in bits
+	var xpos = (x2*256)+x1;
+	
+	// Make 0 the neutral position
+	xpos = xpos - (min+max)/2;
+	
+	// Get a value between -2 and 2
+	xpos = xpos/((min+max)/4);
+	
+	// Get input in bytes from the buffer
+	var y1 = parseInt(data[this.HIDCoordinates.y]);
+	var y2 = parseInt(data[this.HIDCoordinates.y+1]);
+	
+	// Get value in bits
+	var ypos = (y2*256)+y1;
+	
+	// Make 0 the neutral position
+	ypos = ypos - (min+max)/2;
+	
+	// Get a value between -2 and 2
+	ypos = ypos/((min+max)/4);
+	
+	return {
+		x: xpos,
+		y: ypos
+	};
 };
 
 /**


### PR DESCRIPTION
Only a single byte was used for the x and y positions of the analog sticks, which caused it to work improperly. I've made it so both 2 bytes per position of the analog sticks are used and reduced to a value between -2 and 2, where 0 is the neutral position. I've also included a dead zone (currently set to 0.75), to prevent hypersensitivity of the analog sticks.
I recommend finding a way to return the values set to the sticks in some way when for example xbox.on('leftstickUp') is called.